### PR TITLE
step0 Scope - Keep the welcome paragraph visible after course start?

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ TBD-welcome-paragraph
 
 ## How to start this course
 
-1. Above these instructions, right-click **Use this template** and open the link in a new tab.
+1. Above these instructions, click **Use this template**, then right-click on the "Create a new repository" option from the drop-down menu and open the link in a new tab.
    ![Use this template](https://user-images.githubusercontent.com/1221423/169618716-fb17528d-f332-4fc5-a11a-eaa23562665e.png)
 2. In the new tab, follow the prompts to create a new repository.
    - For owner, choose your personal account or an organization to host the repository.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _TBD-course-description_
 -->
 
 <details id=0 open>
-<summary><h2>Details of this course</h2></summary>
+<summary><h2>Course Aims</h2></summary>
 
 TBD-welcome-paragraph
 
@@ -30,6 +30,10 @@ TBD-welcome-paragraph
 - **What you'll build**: TBD-result.
 - **Prerequisites**: TBD-prerequisites.
 - **How long**: This course is TBD-step-count steps long and takes less than TBD-duration to complete.
+
+</details>
+
+<!--step0-->
 
 ## How to start this course
 
@@ -41,7 +45,7 @@ TBD-welcome-paragraph
    ![Create a new repository](https://user-images.githubusercontent.com/1221423/169618722-406dc508-add4-4074-83f0-c7a7ad87f6f3.png)
 3. After your new repository is created, wait about 20 seconds, then refresh the page. Follow the step-by-step instructions in the new repository's README.
 
-</details>
+<!--endstep0-->
 
 <!--
   <<< Author notes: Step 1 >>>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _TBD-course-description_
   Do not use quotes on the <details> tag attributes.
 -->
 
-<!--step0-->
+<details id=0 open>
 
 TBD-welcome-paragraph
 
@@ -40,7 +40,7 @@ TBD-welcome-paragraph
    ![Create a new repository](https://user-images.githubusercontent.com/1221423/169618722-406dc508-add4-4074-83f0-c7a7ad87f6f3.png)
 3. After your new repository is created, wait about 20 seconds, then refresh the page. Follow the step-by-step instructions in the new repository's README.
 
-<!--endstep0-->
+</details>
 
 <!--
   <<< Author notes: Step 1 >>>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ _TBD-course-description_
 -->
 
 <details id=0 open>
+<summary><h2>Details of this course</h2></summary>
 
 TBD-welcome-paragraph
 


### PR DESCRIPTION
### Why:

Some learners would like to browse Step 0.

### Discussed in https://github.com/orgs/skills/discussions/24

<div type='discussions-op-text'>

<sup>Originally posted by **markpatterson27** August 15, 2022</sup>
Should the welcome paragraph be included in the step0 scope?

The welcome paragraph includes the course details: 'Who is this for', 'What you'll learn', etc. This paragraph is hidden (along with the 'How to start this course' section) when the course is started (i.e. new repo created from template). I think this paragraph is still useful after the course has started and shouldn't be hidden.

Before opening a series of PRs, I was wondering what other peoples opinions are. Should the welcome paragraph remain visible after course start, or should it be hidden out of the way?</div>

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
I changed the style of Step 0.
I put Step 0 in a `<details>` tag instead of commenting it out.

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
