### PR TITLE
Add `get_current_step` jobs

### DIFF
--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -27,8 +27,7 @@ jobs:
         uses: actions/checkout@v3
       - id: get_step
         run: |
-          echo "::echo::on"
-          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
 

--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -19,14 +19,31 @@ permissions:
   contents: write
 
 jobs:
+  get_current_step:
+    name: Check current step number
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: get_step
+        run: |
+          echo "::echo::on"
+          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+    outputs:
+      current_step: ${{ steps.get_step.outputs.current_step }}
+
   on_start:
     name: On start
+    needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 0
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 0 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest

--- a/.github/workflows/1-tbd.yml
+++ b/.github/workflows/1-tbd.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/1-tbd.yml
+++ b/.github/workflows/1-tbd.yml
@@ -18,14 +18,31 @@ permissions:
   contents: write
 
 jobs:
+  get_current_step:
+    name: Check current step number
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: get_step
+        run: |
+          echo "::echo::on"
+          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+    outputs:
+      current_step: ${{ steps.get_step.outputs.current_step }}
+
   on_TBD-step-1-event:
     name: On TBD-step-1-event
+    needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 1
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 1 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest

--- a/.github/workflows/1-tbd.yml
+++ b/.github/workflows/1-tbd.yml
@@ -26,8 +26,7 @@ jobs:
         uses: actions/checkout@v3
       - id: get_step
         run: |
-          echo "::echo::on"
-          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
 

--- a/.github/workflows/1-tbd.yml
+++ b/.github/workflows/1-tbd.yml
@@ -8,7 +8,8 @@ name: Step 1, TBD-step-1-name
 # Reference https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:
-  TBD-step-1-event:
+  # Add events that trigger this workflow
+  # TBD-step-1-event:
 
 # Reference https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:

--- a/.github/workflows/2-tbd.yml
+++ b/.github/workflows/2-tbd.yml
@@ -8,7 +8,8 @@ name: Step 2, TBD-step-2-name
 # Reference https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:
-  TBD-step-2-event:
+  # Add events that trigger this workflow
+  # TBD-step-2-event:
 
 # Reference https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:

--- a/.github/workflows/2-tbd.yml
+++ b/.github/workflows/2-tbd.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/2-tbd.yml
+++ b/.github/workflows/2-tbd.yml
@@ -26,8 +26,7 @@ jobs:
         uses: actions/checkout@v3
       - id: get_step
         run: |
-          echo "::echo::on"
-          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
 

--- a/.github/workflows/2-tbd.yml
+++ b/.github/workflows/2-tbd.yml
@@ -18,14 +18,31 @@ permissions:
   contents: write
 
 jobs:
+  get_current_step:
+    name: Check current step number
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: get_step
+        run: |
+          echo "::echo::on"
+          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+    outputs:
+      current_step: ${{ steps.get_step.outputs.current_step }}
+
   on_TBD-step-2-event:
     name: On TBD-step-2-event
+    needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 2
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 2 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest

--- a/.github/workflows/3-tbd.yml
+++ b/.github/workflows/3-tbd.yml
@@ -18,14 +18,31 @@ permissions:
   contents: write
 
 jobs:
+  get_current_step:
+    name: Check current step number
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: get_step
+        run: |
+          echo "::echo::on"
+          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+    outputs:
+      current_step: ${{ steps.get_step.outputs.current_step }}
+
   on_TBD-step-3-event:
     name: On TBD-step-3-event
+    needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 3
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 3 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest

--- a/.github/workflows/3-tbd.yml
+++ b/.github/workflows/3-tbd.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/3-tbd.yml
+++ b/.github/workflows/3-tbd.yml
@@ -26,8 +26,7 @@ jobs:
         uses: actions/checkout@v3
       - id: get_step
         run: |
-          echo "::echo::on"
-          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
 

--- a/.github/workflows/3-tbd.yml
+++ b/.github/workflows/3-tbd.yml
@@ -8,7 +8,8 @@ name: Step 3, TBD-step-3-name
 # Reference https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:
-  TBD-step-3-event:
+  # Add events that trigger this workflow
+  # TBD-step-3-event:
 
 # Reference https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:

--- a/.github/workflows/4-tbd.yml
+++ b/.github/workflows/4-tbd.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/4-tbd.yml
+++ b/.github/workflows/4-tbd.yml
@@ -18,14 +18,31 @@ permissions:
   contents: write
 
 jobs:
+  get_current_step:
+    name: Check current step number
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: get_step
+        run: |
+          echo "::echo::on"
+          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+    outputs:
+      current_step: ${{ steps.get_step.outputs.current_step }}
+
   on_TBD-step-4-event:
     name: On TBD-step-4-event
+    needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 4
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 4 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest

--- a/.github/workflows/4-tbd.yml
+++ b/.github/workflows/4-tbd.yml
@@ -8,7 +8,8 @@ name: Step 4, TBD-step-4-name
 # Reference https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:
-  TBD-step-4-event:
+  # Add events that trigger this workflow
+  # TBD-step-4-event:
 
 # Reference https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:

--- a/.github/workflows/4-tbd.yml
+++ b/.github/workflows/4-tbd.yml
@@ -26,8 +26,7 @@ jobs:
         uses: actions/checkout@v3
       - id: get_step
         run: |
-          echo "::echo::on"
-          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
 

--- a/.github/workflows/5-merge-your-pull-request.yml
+++ b/.github/workflows/5-merge-your-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/5-merge-your-pull-request.yml
+++ b/.github/workflows/5-merge-your-pull-request.yml
@@ -27,8 +27,7 @@ jobs:
         uses: actions/checkout@v3
       - id: get_step
         run: |
-          echo "::echo::on"
-          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
 

--- a/.github/workflows/5-merge-your-pull-request.yml
+++ b/.github/workflows/5-merge-your-pull-request.yml
@@ -19,15 +19,31 @@ permissions:
   contents: write
 
 jobs:
+  get_current_step:
+    name: Check current step number
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: get_step
+        run: |
+          echo "::echo::on"
+          echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+    outputs:
+      current_step: ${{ steps.get_step.outputs.current_step }}
+
   on_merge:
     name: On merge
+    needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 5
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template }}
-    # TBD replace `skills` with your organization name, if applicable
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 5 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ TBD-welcome-paragraph
    ![Create a new repository](https://user-images.githubusercontent.com/1221423/169618722-406dc508-add4-4074-83f0-c7a7ad87f6f3.png)
 3. After your new repository is created, wait about 20 seconds, then refresh the page. Follow the step-by-step instructions in the new repository's README.
 
+<!--endstep0-->
+
 <!--
   <<< Author notes: Step 1 >>>
   Choose 3-5 steps for your course.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ _TBD-course-description_
   Do not use quotes on the <details> tag attributes.
 -->
 
-<details id=0 open>
-<summary><h2>Course Aims</h2></summary>
+<!--step0-->
 
 TBD-welcome-paragraph
 
@@ -30,10 +29,6 @@ TBD-welcome-paragraph
 - **What you'll build**: TBD-result.
 - **Prerequisites**: TBD-prerequisites.
 - **How long**: This course is TBD-step-count steps long and takes less than TBD-duration to complete.
-
-</details>
-
-<!--step0-->
 
 ## How to start this course
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _TBD-course-description_
 -->
 
 <details id=0 open>
-<summary><h2>Details of this course</h2></summary>
+<summary><h2>Course Aims</h2></summary>
 
 TBD-welcome-paragraph
 
@@ -30,6 +30,10 @@ TBD-welcome-paragraph
 - **What you'll build**: TBD-result.
 - **Prerequisites**: TBD-prerequisites.
 - **How long**: This course is TBD-step-count steps long and takes less than TBD-duration to complete.
+
+</details>
+
+<!--step0-->
 
 ## How to start this course
 
@@ -41,7 +45,7 @@ TBD-welcome-paragraph
    ![Create a new repository](https://user-images.githubusercontent.com/1221423/169618722-406dc508-add4-4074-83f0-c7a7ad87f6f3.png)
 3. After your new repository is created, wait about 20 seconds, then refresh the page. Follow the step-by-step instructions in the new repository's README.
 
-</details>
+<!--endstep0-->
 
 <!--
   <<< Author notes: Step 1 >>>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _TBD-course-description_
   Do not use quotes on the <details> tag attributes.
 -->
 
-<!--step0-->
+<details id=0 open>
 
 TBD-welcome-paragraph
 
@@ -40,7 +40,7 @@ TBD-welcome-paragraph
    ![Create a new repository](https://user-images.githubusercontent.com/1221423/169618722-406dc508-add4-4074-83f0-c7a7ad87f6f3.png)
 3. After your new repository is created, wait about 20 seconds, then refresh the page. Follow the step-by-step instructions in the new repository's README.
 
-<!--endstep0-->
+</details>
 
 <!--
   <<< Author notes: Step 1 >>>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ _TBD-course-description_
 -->
 
 <details id=0 open>
+<summary><h2>Details of this course</h2></summary>
 
 TBD-welcome-paragraph
 


### PR DESCRIPTION
### Why:

Some courses use `get_current_step` jobs. This feature helps the Actions workflows to function in numerical order.

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
YAML files
Add `get_current_step` jobs

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
